### PR TITLE
Add rsp_api_exports.ver file

### DIFF
--- a/rsp_api_export.ver
+++ b/rsp_api_export.ver
@@ -1,0 +1,9 @@
+{ global:
+PluginStartup;
+PluginShutdown;
+PluginGetVersion;
+RomOpen;
+DoRspCycles;
+InitiateRSP;
+RomClosed;
+local: *; };


### PR DESCRIPTION
This file seems to be missing from here, but the Android build scripts seem to require it.