### PR TITLE
Use HLE video by default if HLEVIDEO is set

### DIFF
--- a/module.c
+++ b/module.c
@@ -159,9 +159,14 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
         bSaveConfig = 1;
     }
 
+#ifndef HLEVIDEO
+    int hlevideo = 0;
+#else
+    int hlevideo = 1;
+#endif
     /* set the default values for this plugin */
     ConfigSetDefaultFloat(l_ConfigRsp, "Version", CONFIG_PARAM_VERSION,  "Mupen64Plus cxd4 RSP Plugin config parameter version number");
-    ConfigSetDefaultBool(l_ConfigRsp, "DisplayListToGraphicsPlugin", 0, "Send display lists to the graphics plugin");
+    ConfigSetDefaultBool(l_ConfigRsp, "DisplayListToGraphicsPlugin", hlevideo, "Send display lists to the graphics plugin");
     ConfigSetDefaultBool(l_ConfigRsp, "AudioListToAudioPlugin", 0, "Send audio lists to the audio plugin");
     ConfigSetDefaultBool(l_ConfigRsp, "WaitForCPUHost", 0, "Force CPU-RSP signals synchronization");
     ConfigSetDefaultBool(l_ConfigRsp, "SupportCPUSemaphoreLock", 0, "Support CPU-RSP semaphore lock");

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -136,6 +136,11 @@ ifeq ($(CPU), X86)
   endif
 endif
 
+HLEVIDEO ?= 0
+ifeq ($(HLEVIDEO), 1)
+  CFLAGS += -DHLEVIDEO
+endif
+
 # Since we are building a shared library, we must compile with -fPIC on some architectures
 # On 32-bit x86 systems we do not want to use -fPIC because we don't have to and it has a big performance penalty on this arch
 ifeq ($(PIC), 1)


### PR DESCRIPTION
This flag was already mentioned in the docs but it wasn't used for anything:

https://github.com/mupen64plus/mupen64plus-rsp-cxd4/blob/master/projects/unix/Makefile#L296