### PR TITLE
Force LLE graphics on ROMs known to require it

### DIFF
--- a/module.c
+++ b/module.c
@@ -59,6 +59,7 @@ NOINLINE void update_conf(const char* source)
     memset(conf, 0, sizeof(conf));
     m64p_rom_header ROM_HEADER;
     CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(ROM_HEADER), &ROM_HEADER);
+
     if (strstr((char*)ROM_HEADER.Name, (const char*)"WORLD DRIVER CHAMP") != NULL)
         CFG_HLE_GFX = 0;
     else if (strstr((char*)ROM_HEADER.Name, (const char*)"Indiana Jones") != NULL)
@@ -75,9 +76,14 @@ NOINLINE void update_conf(const char* source)
         CFG_HLE_GFX = 0;
     else
         CFG_HLE_GFX = ConfigGetParamBool(l_ConfigRsp, "DisplayListToGraphicsPlugin");
+
     CFG_HLE_AUD = ConfigGetParamBool(l_ConfigRsp, "AudioListToAudioPlugin");
     CFG_WAIT_FOR_CPU_HOST = ConfigGetParamBool(l_ConfigRsp, "WaitForCPUHost");
-    CFG_MEND_SEMAPHORE_LOCK = ConfigGetParamBool(l_ConfigRsp, "SupportCPUSemaphoreLock");
+
+    if (strstr((char*)ROM_HEADER.Name, (const char*)"NBA SHOWTIME") != NULL)
+        CFG_MEND_SEMAPHORE_LOCK = 1;
+    else
+        CFG_MEND_SEMAPHORE_LOCK = ConfigGetParamBool(l_ConfigRsp, "SupportCPUSemaphoreLock");
 }
 
 static void DebugMessage(int level, const char *message, ...)

--- a/module.c
+++ b/module.c
@@ -30,6 +30,7 @@ RSP_INFO RSP_INFO_NAME;
 
 #if defined(M64P_PLUGIN_API)
 
+#include <m64p_frontend.h>
 #include <stdarg.h>
 
 #define RSP_PLUGIN_API_VERSION 0x020000
@@ -51,12 +52,29 @@ ptr_ConfigGetParameter     ConfigGetParameter = NULL;
 ptr_ConfigSetDefaultFloat  ConfigSetDefaultFloat;
 ptr_ConfigSetDefaultBool   ConfigSetDefaultBool = NULL;
 ptr_ConfigGetParamBool     ConfigGetParamBool = NULL;
+ptr_CoreDoCommand          CoreDoCommand = NULL;
 
 NOINLINE void update_conf(const char* source)
 {
     memset(conf, 0, sizeof(conf));
-
-    CFG_HLE_GFX = ConfigGetParamBool(l_ConfigRsp, "DisplayListToGraphicsPlugin");
+    m64p_rom_header ROM_HEADER;
+    CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(ROM_HEADER), &ROM_HEADER);
+    if (strstr((char*)ROM_HEADER.Name, (const char*)"WORLD DRIVER CHAMP") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"Indiana Jones") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"Rogue Squadron") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"rogue squadron") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"Battle for Naboo") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"Stunt Racer 64") != NULL)
+        CFG_HLE_GFX = 0;
+    else if (strstr((char*)ROM_HEADER.Name, (const char*)"GAUNTLET LEGENDS") != NULL)
+        CFG_HLE_GFX = 0;
+    else
+        CFG_HLE_GFX = ConfigGetParamBool(l_ConfigRsp, "DisplayListToGraphicsPlugin");
     CFG_HLE_AUD = ConfigGetParamBool(l_ConfigRsp, "AudioListToAudioPlugin");
     CFG_WAIT_FOR_CPU_HOST = ConfigGetParamBool(l_ConfigRsp, "WaitForCPUHost");
     CFG_MEND_SEMAPHORE_LOCK = ConfigGetParamBool(l_ConfigRsp, "SupportCPUSemaphoreLock");
@@ -118,6 +136,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
     ConfigSetDefaultFloat = (ptr_ConfigSetDefaultFloat) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultFloat");
     ConfigSetDefaultBool = (ptr_ConfigSetDefaultBool) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultBool");
     ConfigGetParamBool = (ptr_ConfigGetParamBool) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamBool");
+    CoreDoCommand = (ptr_CoreDoCommand) osal_dynlib_getproc(CoreLibHandle, "CoreDoCommand");
 
     if (!ConfigOpenSection || !ConfigDeleteSection || !ConfigSetParameter || !ConfigGetParameter ||
         !ConfigSetDefaultBool || !ConfigGetParamBool || !ConfigSetDefaultFloat)

--- a/su.c
+++ b/su.c
@@ -57,8 +57,6 @@ void SP_CP0_MF(unsigned int rt, unsigned int rd)
     if (rd == 0x7) {
         if (CFG_MEND_SEMAPHORE_LOCK == 0)
             return;
-        if (CFG_HLE_GFX | CFG_HLE_AUD)
-            return;
         GET_RCP_REG(SP_SEMAPHORE_REG) = 0x00000001;
         GET_RCP_REG(SP_STATUS_REG) |= SP_STATUS_HALT; /* temporary hack */
         return;


### PR DESCRIPTION
This list was taken from the Project64 RDB. This will allow a user to select ```DisplayListToGraphicsPlugin```, but still have it use LLE graphics on games where we know no HLE implementation exists.