### PR TITLE
Fix for arm linux

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -118,7 +118,7 @@ endif
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I../../ -mstackrealign
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I../../
 CPPFLAGS += -DM64P_PLUGIN_API
 LDFLAGS += $(SHARED)
 
@@ -134,6 +134,7 @@ ifeq ($(CPU), X86)
     CPPFLAGS += -DARCH_MIN_SSSE3
     POSTFIX = -ssse3
   endif
+  CFLAGS += -mstackrealign
 endif
 
 ifeq ($(NEON), 1)

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -136,6 +136,11 @@ ifeq ($(CPU), X86)
   endif
 endif
 
+ifeq ($(NEON), 1)
+    CFLAGS   += -mfpu=neon
+    CPPFLAGS += -DUSE_SSE2NEON
+endif
+
 # Since we are building a shared library, we must compile with -fPIC on some architectures
 # On 32-bit x86 systems we do not want to use -fPIC because we don't have to and it has a big performance penalty on this arch
 ifeq ($(PIC), 1)
@@ -297,6 +302,7 @@ targets:
 	@echo "    POSTFIX=name  == String added to the name of the the build (default: '')"
 	@echo "    SSE=version   == Optimize for SSE technology version"
 	@echo "                     (none [default on non-x86], SSE2 [default on x86], SSSE3)"
+	@echo "    NEON=(1|0)    == Optimize for NEON technology version"
 	@echo "  Install Options:"
 	@echo "    PREFIX=path   == install/uninstall prefix (default: /usr/local)"
 	@echo "    LIBDIR=path   == library prefix (default: PREFIX/lib)"

--- a/sse2neon/SSE2NEON.h
+++ b/sse2neon/SSE2NEON.h
@@ -61,10 +61,15 @@
 #define DISABLE_SHUFFLE 1
 #endif
 
-#if GCC
-#define FORCE_INLINE					inline __attribute__((always_inline))
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma push_macro("FORCE_INLINE")
+#	pragma push_macro("ALIGN_STRUCT")
+#	define FORCE_INLINE       static inline __attribute__((always_inline))
+#	define ALIGN_STRUCT(x)    __attribute__((aligned(x)))
 #else
-#define FORCE_INLINE					inline
+#	error "Macro name collisions may happens with unknown compiler"
+#	define FORCE_INLINE       static inline
+#	define ALIGN_STRUCT(x)    __declspec(align(x))
 #endif
 
 #include "arm_neon.h"


### PR DESCRIPTION
-Makefile: Add neon option so SSE2NEON can be used.
-Makefile:build fails if -mstackrealign is present. Move it to target x86.
-SSE2NEON.h: Update from upstream https://github.com/jratcliff63367/sse2neon/blob/master/SSE2NEON.h#L111. Without this update build fails. Without this change there are many "(.text+0x0): multiple definition of function..." error messages.