### PR TITLE
Allow Rogue Squadron to run in HLE GFX

### DIFF
--- a/module.c
+++ b/module.c
@@ -64,10 +64,6 @@ NOINLINE void update_conf(const char* source)
         CFG_HLE_GFX = 0;
     else if (strstr((char*)ROM_HEADER.Name, (const char*)"Indiana Jones") != NULL)
         CFG_HLE_GFX = 0;
-    else if (strstr((char*)ROM_HEADER.Name, (const char*)"Rogue Squadron") != NULL)
-        CFG_HLE_GFX = 0;
-    else if (strstr((char*)ROM_HEADER.Name, (const char*)"rogue squadron") != NULL)
-        CFG_HLE_GFX = 0;
     else if (strstr((char*)ROM_HEADER.Name, (const char*)"Battle for Naboo") != NULL)
         CFG_HLE_GFX = 0;
     else if (strstr((char*)ROM_HEADER.Name, (const char*)"Stunt Racer 64") != NULL)


### PR DESCRIPTION
GLideN64 has successfully implemented the microcode for this game (not released to the public yet, but that is coming soon), so this can be removed