### PR TITLE
set SP_STATUS bits before calling ProcessDList

### DIFF
--- a/module.c
+++ b/module.c
@@ -304,14 +304,14 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
 
         if (*(pi32)(DMEM + 0xFF0) == 0x00000000)
             break; /* Resident Evil 2, null task pointers */
+        GET_RCP_REG(SP_STATUS_REG) |=
+            SP_STATUS_SIG2 | SP_STATUS_BROKE | SP_STATUS_HALT
+        ;
         if (GET_RSP_INFO(ProcessDlistList) == NULL)
             { /* branch */ }
         else
             GET_RSP_INFO(ProcessDlistList)();
 
-        GET_RCP_REG(SP_STATUS_REG) |=
-            SP_STATUS_SIG2 | SP_STATUS_BROKE | SP_STATUS_HALT
-        ;
         if (GET_RCP_REG(SP_STATUS_REG) & SP_STATUS_INTR_BREAK) {
             GET_RCP_REG(MI_INTR_REG) |= 0x00000001;
             GET_RSP_INFO(CheckInterrupts)();


### PR DESCRIPTION
GFX plugins recently gained the ability to modify SP_STATUS.

https://github.com/mupen64plus/mupen64plus-core/pull/425

This will set ```TASKDONE | HALT | BROKE``` before calling ProcessDList, and the GFX plugin can unset these bits if it needs.

The result for current GFX plugins will be the same, they never read or used SP_STATUS before, so it doesn't make a difference if these bits are set before or after ProcessDList