### PR TITLE
Merge changes from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 *.asm
 *.s
-*.o
 
-/obj
+*.o
+*.so
+obj
 
 *.obj
 *.dll

--- a/lto.c
+++ b/lto.c
@@ -1,0 +1,39 @@
+/******************************************************************************\
+* Project:  Primitive LTO Merger Substitute                                    *
+* Authors:  Iconoclast                                                         *
+* Release:  2018.03.17                                                         *
+* License:  CC0 Public Domain Dedication                                       *
+*                                                                              *
+* To the extent possible under law, the author(s) have dedicated all copyright *
+* and related and neighboring rights to this software to the public domain     *
+* worldwide. This software is distributed without any warranty.                *
+*                                                                              *
+* You should have received a copy of the CC0 Public Domain Dedication along    *
+* with this software.                                                          *
+* If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.             *
+\******************************************************************************/
+
+/*
+ * A single compile-and-link command will be sufficient with this method.
+ *
+ * A command exemplifying this on UNIX with all optimizations in tact may be:
+ *   $ cc --shared -o rsp.so lto.c -O3 -msse2 -DARCH_MIN_SSE2 -s
+ *
+ * To control the link-time stage during build with a separate command:
+ *   $ gcc -c -o rsp.o lto.c -O3 -msse2 -DARCH_MIN_SSE2
+ *   $ ld --shared -o rsp.so -lc rsp.o --strip-all
+ */
+
+#include "module.c"
+#include "su.c"
+
+#include "vu/vu.c"
+
+#include "vu/multiply.c"
+#include "vu/add.c"
+#include "vu/select.c"
+#include "vu/logical.c"
+#include "vu/divide.c"
+#if 0
+#include "vu/pack.c"
+#endif

--- a/make.sh
+++ b/make.sh
@@ -1,8 +1,6 @@
 mkdir -p obj
 mkdir -p obj/vu
 
-# The below path configuration will only work if you have this `make.sh` script
-# installed to the parent directory just outside the RSP source when you run it.
 src="." # or an absolute path, like "/home/user/rsp"
 obj="$src/obj"
 
@@ -16,18 +14,10 @@ OBJ_LIST="\
     $obj/vu/logical.o \
     $obj/vu/divide.o"
 
-FLAGS_ANSI="\
-    -O3 \
-    -fPIC \
-    -DPLUGIN_API_VERSION=0x0101 \
-    -march=native \
-    -mstackrealign \
-    -Wall \
-    -pedanticz"
+FLAGS_ANSI="-fPIC -DPLUGIN_API_VERSION=0x0101 -mstackrealign -Wall -pedantic"
 
 if [ `uname -m` == 'x86_64' ]; then
 FLAGS_x86="\
-    -O3 \
     -masm=intel \
     -fPIC \
     -DPLUGIN_API_VERSION=0x0101 \
@@ -38,11 +28,10 @@ FLAGS_x86="\
     -pedantic \
     -Wall -Wshadow -Wredundant-decls -Wextra -Wcast-align -Wcast-qual \
     -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op
-    -Wmissing-include-dirs -Wstrict-overflow=5 -Wundef -Wno-unused \
+    -Wmissing-include-dirs -Wstrict-overflow=1 -Wundef -Wno-unused \
     -Wno-variadic-macros -Wno-parentheses -fdiagnostics-show-option"
 else
 FLAGS_x86="\
-    -O3 \
     -masm=intel \
     -DPLUGIN_API_VERSION=0x0101 \
     -DARCH_MIN_SSE2 \
@@ -52,25 +41,25 @@ FLAGS_x86="\
     -pedantic \
     -Wall -Wshadow -Wredundant-decls -Wextra -Wcast-align -Wcast-qual \
     -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op
-    -Wmissing-include-dirs -Wstrict-overflow=5 -Wundef -Wno-unused \
+    -Wmissing-include-dirs -Wstrict-overflow=1 -Wundef -Wno-unused \
     -Wno-variadic-macros -Wno-parentheses -fdiagnostics-show-option"
 fi
 C_FLAGS=$FLAGS_x86 # default since Intel SIMD was the most tested
 
 echo Compiling C source code...
-cc -S $C_FLAGS -o $obj/module.s  $src/module.c
-cc -S $C_FLAGS -o $obj/su.s      $src/su.c
-cc -S $C_FLAGS -o $obj/vu/vu.s       $src/vu/vu.c
-cc -S $C_FLAGS -o $obj/vu/multiply.s $src/vu/multiply.c
-cc -S $C_FLAGS -o $obj/vu/add.s      $src/vu/add.c
-cc -S $C_FLAGS -o $obj/vu/select.s   $src/vu/select.c
-cc -S $C_FLAGS -o $obj/vu/logical.s  $src/vu/logical.c
-cc -S $C_FLAGS -o $obj/vu/divide.s   $src/vu/divide.c
+cc -S -Os $C_FLAGS -o $obj/module.s  $src/module.c
+cc -S -O3 $C_FLAGS -o $obj/su.s      $src/su.c
+cc -S -O3 $C_FLAGS -o $obj/vu/vu.s       $src/vu/vu.c
+cc -S -O3 $C_FLAGS -o $obj/vu/multiply.s $src/vu/multiply.c
+cc -S -O3 $C_FLAGS -o $obj/vu/add.s      $src/vu/add.c
+cc -S -O3 $C_FLAGS -o $obj/vu/select.s   $src/vu/select.c
+cc -S -O3 $C_FLAGS -o $obj/vu/logical.s  $src/vu/logical.c
+cc -S -O2 $C_FLAGS -o $obj/vu/divide.s   $src/vu/divide.c
 
 echo Assembling compiled sources...
-as --statistics -o $obj/module.o $obj/module.s
-as --statistics -o $obj/su.o     $obj/su.s
-as --statistics -o $obj/vu/vu.o  $obj/vu/vu.s
+as -o $obj/module.o $obj/module.s
+as -o $obj/su.o     $obj/su.s
+as -o $obj/vu/vu.o  $obj/vu/vu.s
 as -o $obj/vu/multiply.o $obj/vu/multiply.s
 as -o $obj/vu/add.o      $obj/vu/add.s
 as -o $obj/vu/select.o   $obj/vu/select.s
@@ -78,5 +67,5 @@ as -o $obj/vu/logical.o  $obj/vu/logical.s
 as -o $obj/vu/divide.o   $obj/vu/divide.s
 
 echo Linking assembled object files...
-ld --shared -o $obj/rspdebug.so $OBJ_LIST
-strip -o $obj/rsp.so $obj/rspdebug.so
+ld --shared -o $obj/rspdebug.so -lc $OBJ_LIST
+strip -o $obj/rsp.so $obj/rspdebug.so --strip-all

--- a/make_w32.cmd
+++ b/make_w32.cmd
@@ -1,7 +1,18 @@
 @ECHO OFF
 TITLE MinGW Compiler Suite Invocation
 
+REM If you have MinGW on a different drive letter or installed at a custom path
+REM (or just not yet installed at all), this build script may not work out of
+REM the box for most Windows users.  Alternatives include MinGW-w32 or trying
+REM to execute the Unix shell script "make.sh" from Windows 10+ or Git Bash.
+
+REM The following line is the only one you should ever need to change.
 set MinGW=C:\MinGW
+
+set lib=%MinGW%\lib
+set bin=%MinGW%\bin
+set inc=%MinGW%\include
+
 REM set rsp=%USERPROFILE%\rsp
 set rsp=%CD%
 set obj=%rsp%\obj
@@ -16,20 +27,16 @@ set OBJ_LIST=^
 %obj%\vu\logical.o ^
 %obj%\vu\divide.o
 
-set FLAGS_ANSI=-O3^
+set FLAGS_ANSI=-Wall -pedantic^
  -DPLUGIN_API_VERSION=0x0101^
- -march=native^
  -mstackrealign^
- -Wall^
- -pedantic
-set FLAGS_x86=-O3^
+ -march=native
+set FLAGS_x86=-Wall -pedantic^
  -masm=intel^
  -DPLUGIN_API_VERSION=0x0101^
  -DARCH_MIN_SSE2^
- -march=native^
  -mstackrealign^
- -Wall^
- -pedantic
+ -march=native
 set C_FLAGS=%FLAGS_x86%
 
 if not exist obj (
@@ -37,31 +44,33 @@ mkdir obj
 cd obj
 mkdir vu
 )
-cd %MinGW%\bin
+cd /D %bin%
 
 ECHO Compiling C source code...
-cc -S %C_FLAGS% -o %obj%\module.asm      %rsp%\module.c
-cc -S %C_FLAGS% -o %obj%\su.asm          %rsp%\su.c
-cc -S %C_FLAGS% -o %obj%\vu\vu.asm       %rsp%\vu\vu.c
-cc -S %C_FLAGS% -o %obj%\vu\multiply.asm %rsp%\vu\multiply.c
-cc -S %C_FLAGS% -o %obj%\vu\add.asm      %rsp%\vu\add.c
-cc -S %C_FLAGS% -o %obj%\vu\select.asm   %rsp%\vu\select.c
-cc -S %C_FLAGS% -o %obj%\vu\logical.asm  %rsp%\vu\logical.c
-cc -S %C_FLAGS% -o %obj%\vu\divide.asm   %rsp%\vu\divide.c
+@ECHO ON
+gcc -Os -S %C_FLAGS% -o %obj%\module.asm      %rsp%\module.c
+gcc -O3 -S %C_FLAGS% -o %obj%\su.asm          %rsp%\su.c
+gcc -O3 -S %C_FLAGS% -o %obj%\vu\vu.asm       %rsp%\vu\vu.c
+gcc -O3 -S %C_FLAGS% -o %obj%\vu\multiply.asm %rsp%\vu\multiply.c
+gcc -O3 -S %C_FLAGS% -o %obj%\vu\add.asm      %rsp%\vu\add.c
+gcc -O3 -S %C_FLAGS% -o %obj%\vu\select.asm   %rsp%\vu\select.c
+gcc -O3 -S %C_FLAGS% -o %obj%\vu\logical.asm  %rsp%\vu\logical.c
+gcc -O2 -S %C_FLAGS% -o %obj%\vu\divide.asm   %rsp%\vu\divide.c
+@ECHO OFF
 ECHO.
 
 ECHO Assembling compiled sources...
-as --statistics -o %obj%\module.o %obj%\module.asm
-as --statistics -o %obj%\su.o     %obj%\su.asm
-as --statistics -o %obj%\vu\vu.o  %obj%\vu\vu.asm
-as -o %obj%\vu\multiply.o %obj%\vu\multiply.asm
-as -o %obj%\vu\add.o      %obj%\vu\add.asm
-as -o %obj%\vu\select.o   %obj%\vu\select.asm
-as -o %obj%\vu\logical.o  %obj%\vu\logical.asm
-as -o %obj%\vu\divide.o   %obj%\vu\divide.asm
+as -o %obj%\module.o            %obj%\module.asm
+as -o %obj%\su.o                %obj%\su.asm
+as -o %obj%\vu\vu.o             %obj%\vu\vu.asm
+as -o %obj%\vu\multiply.o       %obj%\vu\multiply.asm
+as -o %obj%\vu\add.o            %obj%\vu\add.asm
+as -o %obj%\vu\select.o         %obj%\vu\select.asm
+as -o %obj%\vu\logical.o        %obj%\vu\logical.asm
+as -o %obj%\vu\divide.o         %obj%\vu\divide.asm
 ECHO.
 
 ECHO Linking assembled object files...
-ld --shared -e _DllMain@12 -o %obj%\rspdebug.dll %OBJ_LIST% %MinGW%\lib\libkernel32.a
-strip -o %obj%/rsp.dll %obj%/rspdebug.dll
+ld --shared -e _DllMain@12 -o %obj%\rspdebug.dll -L %lib% %OBJ_LIST% -lmsvcrt
+strip -o %obj%\rsp.dll %obj%\rspdebug.dll --strip-all
 PAUSE

--- a/module.c
+++ b/module.c
@@ -314,10 +314,17 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
         GET_RCP_REG(SP_STATUS_REG) |=
             SP_STATUS_SIG2 | SP_STATUS_BROKE | SP_STATUS_HALT
         ;
+#if defined(M64P_PLUGIN_API)
         if (GET_RSP_INFO(ProcessDlistList) == NULL)
             { /* branch */ }
         else
             GET_RSP_INFO(ProcessDlistList)();
+#else
+        if (GET_RSP_INFO(ProcessDList) == NULL)
+            { /* branch */ }
+        else
+            GET_RSP_INFO(ProcessDList)();
+#endif
 
         if ((GET_RCP_REG(SP_STATUS_REG) & SP_STATUS_INTR_BREAK) && (GET_RCP_REG(SP_STATUS_REG) & (SP_STATUS_SIG2 | SP_STATUS_BROKE | SP_STATUS_HALT))) {
             GET_RCP_REG(MI_INTR_REG) |= 0x00000001;
@@ -329,10 +336,17 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
         if (CFG_HLE_AUD == 0)
             break;
 
+#if defined(M64P_PLUGIN_API)
         if (GET_RSP_INFO(ProcessAlistList) == NULL)
             { /* branch */ }
         else
             GET_RSP_INFO(ProcessAlistList)();
+#else
+        if (GET_RSP_INFO(ProcessAList) == NULL)
+            { /* branch */ }
+        else
+            GET_RSP_INFO(ProcessAList)();
+#endif
 
         GET_RCP_REG(SP_STATUS_REG) |=
             SP_STATUS_SIG2 | SP_STATUS_BROKE | SP_STATUS_HALT

--- a/module.c
+++ b/module.c
@@ -74,7 +74,7 @@ ptr_CoreDoCommand          CoreDoCommand = NULL;
 
 NOINLINE void update_conf(const char* source)
 {
-    memset(conf, 0, sizeof(conf));
+    memset(conf, 0, 32);
     m64p_rom_header ROM_HEADER;
     CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(ROM_HEADER), &ROM_HEADER);
 

--- a/module.c
+++ b/module.c
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  Module Subsystem Interface to SP Interpreter Core                  *
 * Authors:  Iconoclast                                                         *
-* Release:  2016.11.05                                                         *
+* Release:  2018.03.21                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -27,6 +27,20 @@
 
 #include "module.h"
 #include "su.h"
+
+#include <signal.h>
+#include <setjmp.h>
+
+static jmp_buf CPU_state;
+static void seg_av_handler(int signal_code)
+{
+    longjmp(CPU_state, signal_code);
+}
+static void ISA_op_illegal(int signal_code)
+{
+    message("Plugin built for SIMD extensions this CPU does not support!");
+    raise(signal_code); /* e.g., rsp.dll built with -mssse3; the CPU is SSE2. */
+}
 
 RSP_INFO RSP_INFO_NAME;
 
@@ -252,7 +266,7 @@ EXPORT void CALL DllAbout(p_void hParent)
 
 EXPORT void CALL DllConfig(p_void hParent)
 {
-    my_system("sp_cfgui");
+    system("sp_cfgui");
     update_conf(CFG_FILE);
 
     if (DMEM == IMEM || GET_RCP_REG(SP_PC_REG) % 4096 == 0x00000000)
@@ -269,27 +283,28 @@ EXPORT void CALL DllConfig(p_void hParent)
 
 EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
 {
+    static char task_debug[] = "unknown task type:  0x????????";
+    char* task_debug_type;
     OSTask_type task_type;
     register unsigned int i;
 
-    if (GET_RCP_REG(SP_STATUS_REG) & 0x00000003)
-    {
+    if (GET_RCP_REG(SP_STATUS_REG) & 0x00000003) {
         message("SP_STATUS_HALT");
         return 0x00000000;
     }
+    task_debug_type = &task_debug[strlen("unknown task type:  0x")];
 
-    task_type = 0x00000000
 #ifdef USE_CLIENT_ENDIAN
-      | *((pi32)(DMEM + 0x000FC0U))
+    memcpy(&task_type, DMEM + 0xFC0, 4);
 #else
-      | (u32)DMEM[0xFC0] << 24
-      | (u32)DMEM[0xFC1] << 16
-      | (u32)DMEM[0xFC2] <<  8
-      | (u32)DMEM[0xFC3] <<  0
-#endif
+    task_type = 0x00000000
+      | (u32)(DMEM[0xFC0 ^ 0] & 0xFFu) << 24
+      | (u32)(DMEM[0xFC1 ^ 0] & 0xFFu) << 16
+      | (u32)(DMEM[0xFC2 ^ 0] & 0xFFu) <<  8
+      | (u32)(DMEM[0xFC3 ^ 0] & 0xFFu) <<  0
     ;
+#endif
     switch (task_type) {
-#ifdef EXTERN_COMMAND_LIST_GBI
     case M_GFXTASK:
         if (CFG_HLE_GFX == 0)
             break;
@@ -310,8 +325,6 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
         }
         GET_RCP_REG(DPC_STATUS_REG) &= ~0x00000002ul; /* DPC_STATUS_FREEZE */
         return 0;
-#endif
-#ifdef EXTERN_COMMAND_LIST_ABI
     case M_AUDTASK:
         if (CFG_HLE_AUD == 0)
             break;
@@ -329,7 +342,6 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
             GET_RSP_INFO(CheckInterrupts)();
         }
         return 0;
-#endif
     case M_VIDTASK:
         message("M_VIDTASK");
         break;
@@ -346,10 +358,15 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
             break;
         GET_RSP_INFO(ShowCFB)(); /* forced FB refresh in case gfx plugin skip */
         break;
+    default:
+        if (task_type == 0x8BC43B5D)
+            break; /* CIC boot code sent to the RSP */
+        sprintf(task_debug_type, "%08lX", (unsigned long)task_type);
+        message(task_debug);
     }
 
 #ifdef WAIT_FOR_CPU_HOST
-    for (i = 0; i < 32; i++)
+    for (i = 0; i < NUMBER_OF_SCALAR_REGISTERS; i++)
         MFC0_count[i] = 0;
 #endif
     run_task();
@@ -387,7 +404,7 @@ EXPORT void CALL GetDllInfo(PLUGIN_INFO *PluginInfo)
 {
     PluginInfo -> Version = PLUGIN_API_VERSION;
     PluginInfo -> Type = PLUGIN_TYPE_RSP;
-    my_strcpy(PluginInfo -> Name, "Static Interpreter");
+    strcpy(PluginInfo -> Name, "Static Interpreter");
     PluginInfo -> NormalMemory = 0;
     PluginInfo -> MemoryBswaped = USE_CLIENT_ENDIAN;
     return;
@@ -406,6 +423,8 @@ void no_LLE(void)
 }
 EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, pu32 CycleCount)
 {
+    int recovered_from_exception;
+
     if (CycleCount != NULL) /* cycle-accuracy not doable with today's hosts */
         *CycleCount = 0;
     update_conf(CFG_FILE);
@@ -425,7 +444,7 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, pu32 CycleCount)
     CR[0x5] = &GET_RCP_REG(SP_DMA_FULL_REG);
     CR[0x6] = &GET_RCP_REG(SP_DMA_BUSY_REG);
     CR[0x7] = &GET_RCP_REG(SP_SEMAPHORE_REG);
-    GET_RCP_REG(SP_PC_REG) = 0x04001000;
+    *(RSP_INFO_NAME.SP_PC_REG) = 0x04001000;
     CR[0x8] = &GET_RCP_REG(DPC_START_REG);
     CR[0x9] = &GET_RCP_REG(DPC_END_REG);
     CR[0xA] = &GET_RCP_REG(DPC_CURRENT_REG);
@@ -443,6 +462,28 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, pu32 CycleCount)
     GBI_phase = GET_RSP_INFO(ProcessRdpList);
     if (GBI_phase == NULL)
         GBI_phase = no_LLE;
+
+    signal(SIGILL, ISA_op_illegal);
+#ifndef _WIN32
+    signal(SIGSEGV, seg_av_handler);
+    for (SR[ra] = 0; SR[ra] < 0x80000000ul; SR[ra] += 0x200000) {
+        recovered_from_exception = setjmp(CPU_state);
+        if (recovered_from_exception)
+            break;
+        SR[at] += DRAM[SR[ra]];
+    }
+    for (SR[at] = 0; SR[at] < 31; SR[at]++) {
+        SR[ra] = (SR[ra] & ~1) >> 1;
+        if (SR[ra] == 0)
+            break;
+    }
+    su_max_address = (1 << SR[at]) - 1;
+#endif
+
+    if (su_max_address < 0x1FFFFFul)
+        su_max_address = 0x1FFFFFul; /* 2 MiB */
+    if (su_max_address > 0xFFFFFFul)
+        su_max_address = 0xFFFFFFul; /* 16 MiB */
     return;
 }
 
@@ -455,9 +496,9 @@ EXPORT void CALL RomClosed(void)
  * If the config file wasn't installed correctly, politely shut errors up.
  */
 #if !defined(M64P_PLUGIN_API)
-    FILE* stream = my_fopen(CFG_FILE, "wb");
-    my_fwrite(conf, 8, 32 / 8, stream);
-    my_fclose(stream);
+    FILE* stream = fopen(CFG_FILE, "wb");
+    fwrite(conf, 8, 32 / 8, stream);
+    fclose(stream);
 #endif
     return;
 }
@@ -470,22 +511,22 @@ NOINLINE void message(const char* body)
     char* argv;
     int i, j;
 
-    argv = my_calloc(my_strlen(body) + 64, 1);
-    my_strcpy(argv, "CMD /Q /D /C \"TITLE RSP Message&&ECHO ");
+    argv = calloc(strlen(body) + 64, 1);
+    strcpy(argv, "CMD /Q /D /C \"TITLE RSP Message&&ECHO ");
     i = 0;
-    j = my_strlen(argv);
+    j = strlen(argv);
     while (body[i] != '\0') {
         if (body[i] == '\n') {
-            my_strcat(argv, "&&ECHO ");
+            strcat(argv, "&&ECHO ");
             ++i;
             j += 7;
             continue;
         }
         argv[j++] = body[i++];
     }
-    my_strcat(argv, "&&PAUSE&&EXIT\"");
-    my_system(argv);
-    my_free(argv);
+    strcat(argv, "&&PAUSE&&EXIT\"");
+    system(argv);
+    free(argv);
 #else
     fputs(body, stdout);
     putchar('\n');
@@ -519,13 +560,13 @@ NOINLINE void update_conf(const char* source)
     for (i = 0; i < 32; i++)
         conf[i] = 0x00;
 
-    stream = my_fopen(source, "rb");
+    stream = fopen(source, "rb");
     if (stream == NULL) {
         message("Failed to read config.");
         return;
     }
-    my_fread(conf, 8, 32 / 8, stream);
-    my_fclose(stream);
+    fread(conf, 8, 32 / 8, stream);
+    fclose(stream);
     return;
 }
 #endif
@@ -548,11 +589,11 @@ void step_SP_commands(uint32_t inst)
     sprintf(&offset[0], "%03X", GET_RCP_REG(SP_PC_REG) & 0xFFF);
     sprintf(&code[0], "%08X", inst);
     strcpy(text, offset);
-    my_strcat(text, "\n");
-    my_strcat(text, code);
+    strcat(text, "\n");
+    strcat(text, code);
     message(text); /* PC offset, MIPS hex. */
     if (output_log != NULL)
-        my_fwrite(endian_swap, 4, 1, output_log);
+        fwrite(endian_swap, 4, 1, output_log);
 }
 #endif
 
@@ -563,13 +604,13 @@ NOINLINE void export_data_cache(void)
     register int i;
  /* const int little_endian = GET_RSP_INFO(MemoryBswaped); */
 
-    DMEM_swapped = my_calloc(4096, 1);
+    DMEM_swapped = calloc(4096, 1);
     for (i = 0; i < 4096; i++)
         DMEM_swapped[i] = DMEM[BES(i)];
-    out = my_fopen("rcpcache.dhex", "wb");
-    my_fwrite(DMEM_swapped, 16, 4096 / 16, out);
-    my_fclose(out);
-    my_free(DMEM_swapped);
+    out = fopen("rcpcache.dhex", "wb");
+    fwrite(DMEM_swapped, 16, 4096 / 16, out);
+    fclose(out);
+    free(DMEM_swapped);
     return;
 }
 NOINLINE void export_instruction_cache(void)
@@ -579,13 +620,13 @@ NOINLINE void export_instruction_cache(void)
     register int i;
  /* const int little_endian = GET_RSP_INFO(MemoryBswaped); */
 
-    IMEM_swapped = my_calloc(4096, 1);
+    IMEM_swapped = calloc(4096, 1);
     for (i = 0; i < 4096; i++)
         IMEM_swapped[i] = IMEM[BES(i)];
-    out = my_fopen("rcpcache.ihex", "wb");
-    my_fwrite(IMEM_swapped, 16, 4096 / 16, out);
-    my_fclose(out);
-    my_free(IMEM_swapped);
+    out = fopen("rcpcache.ihex", "wb");
+    fwrite(IMEM_swapped, 16, 4096 / 16, out);
+    fclose(out);
+    free(IMEM_swapped);
     return;
 }
 void export_SP_memory(void)
@@ -597,189 +638,26 @@ void export_SP_memory(void)
 
 /*
  * Microsoft linker defaults to an entry point of `_DllMainCRTStartup',
- * which attaches several CRT dependencies.  To eliminate CRT dependencies,
- * we direct the linker to cursor the entry point to the lower-level
- * `DllMain' symbol or, alternatively, link with /NOENTRY for no entry point.
+ * which attaches several CRT dependencies.  To eliminate linkage of unused
+ * startup CRT code, we direct the linker to use DllMain as the entry point.
+ *
+ * The same approach is taken with MinGW to get those weird MinGW-specific
+ * messages and unused initializer functions out of the plugin binary.
  */
-#ifdef WIN32
-BOOL WINAPI DllMain(
-    HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+#ifdef _WIN32
+BOOL WINAPI
+DllMain(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     hModule = lpReserved = NULL; /* unused */
-    switch (ul_reason_for_call)
-    {
-case 1: /* DLL_PROCESS_ATTACH */
+    switch (ul_reason_for_call) {
+    case 1:  /* DLL_PROCESS_ATTACH */
+    case 2:  /* DLL_THREAD_ATTACH */
+    case 3:  /* DLL_THREAD_DETACH */
+    case 0:  /* DLL_PROCESS_DETACH */
         break;
-case 2: /* DLL_THREAD_ATTACH */
-        break;
-case 3: /* DLL_THREAD_DETACH */
-        break;
-case 0: /* DLL_PROCESS_DETACH */
-        break;
+    default:
+        message("Unknown reason for call.");
     }
-    return 1; /* TRUE */
+    return TRUE;
 }
 #endif
-
-/*
- * low-level recreations of the C standard library functions for operating
- * systems that define a C run-time or dependency on top of fixed OS calls
- *
- * Currently, this only addresses Microsoft Windows.
- *
- * None of these are meant to out-perform the original functions, by the way
- * (especially with better intrinsic compiler support for stuff like memcpy),
- * just to cut down on I-cache use for performance-irrelevant code sections
- * and to avoid std. lib run-time dependencies on certain operating systems.
- */
-
-NOINLINE p_void my_calloc(size_t count, size_t size)
-{
-#ifdef WIN32
-    return GlobalAlloc(GPTR, size * count);
-#else
-    return calloc(count, size);
-#endif
-}
-
-NOINLINE void my_free(p_void ptr)
-{
-#ifdef WIN32
-    while (GlobalFree(ptr) != NULL)
-        message("GlobalFree() failure");
-#else
-    free(ptr);
-#endif
-    return;
-}
-
-NOINLINE size_t my_strlen(const char* str)
-{
-    size_t ret_slot;
-
-    for (ret_slot = 0; *str != '\0'; ret_slot++, str++)
-        ;
-    return (ret_slot);
-}
-
-NOINLINE char* my_strcpy(char* destination, const char* source)
-{
-    register size_t i;
-    const size_t length = my_strlen(source) + 1; /* including null terminator */
-
-    for (i = 0; i < length; i++)
-        destination[i] = source[i];
-    return (destination);
-}
-
-NOINLINE char* my_strcat(char* destination, const char* source)
-{
-    const size_t length = my_strlen(destination);
-
-    my_strcpy(destination + length, source);
-    return (destination);
-}
-
-NOINLINE int my_system(char* command)
-{
-    int ret_slot;
-#ifdef WIN32
-    static STARTUPINFOA info;
-    static PROCESS_INFORMATION info_process;
-
-    info.cb = sizeof(info);
-    info.dwFillAttribute =
-        FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
-    info.dwFlags = STARTF_USEFILLATTRIBUTE | STARTF_USECOUNTCHARS;
-
-    info.dwXCountChars = 80;
-    info.dwYCountChars = 20;
-
-    ret_slot = CreateProcessA(
-        NULL,
-        command,
-        NULL,
-        NULL,
-        FALSE,
-        0x00000000,
-        NULL,
-        NULL,
-        &info,
-        &info_process
-    );
-
-    WaitForSingleObject(info_process.hProcess, INFINITE);
-    CloseHandle(info_process.hProcess);
-    CloseHandle(info_process.hThread);
-#elif TARGET_OS_IPHONE || TARGET_OS_TV
-	// system not available in iOS
-	ret_slot = 0;
-#else
-    ret_slot = system(command);
-#endif
-    return (ret_slot);
-}
-
-NOINLINE FILE* my_fopen(const char * filename, const char* mode)
-{
-#ifdef WIN32
-#if 0
-    if (mode[1] != 'b')
-        return NULL; /* non-binary yet to be supported? */
-#endif
-    return (FILE *)(HANDLE)CreateFileA(
-        filename,
-        (mode[0] == 'r') ? GENERIC_READ : GENERIC_WRITE,
-        (mode[0] == 'r') ? FILE_SHARE_READ : FILE_SHARE_WRITE,
-        NULL,
-        (mode[0] == 'r') ? OPEN_EXISTING : CREATE_ALWAYS,
-#if 0
-        FILE_FLAG_WRITE_THROUGH | FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING,
-#else
-        (mode[0] == 'r') ? FILE_ATTRIBUTE_NORMAL : FILE_FLAG_WRITE_THROUGH,
-#endif
-        NULL
-    );
-#else
-    return fopen(filename, mode);
-#endif
-}
-
-NOINLINE int my_fclose(FILE* stream)
-{
-    int ret_slot;
-#ifdef WIN32
-    ret_slot = !CloseHandle((HANDLE)stream);
-#else
-    ret_slot = fclose(stream);
-#endif
-    return (ret_slot);
-}
-
-NOINLINE size_t my_fread(p_void ptr, size_t size, size_t count, FILE* stream)
-{
-#ifdef WIN32
-    DWORD ret_slot;
-
-    ReadFile((HANDLE)stream, ptr, size * count, &ret_slot, NULL);
-#else
-    size_t ret_slot;
-
-    ret_slot = fread(ptr, size, count, stream);
-#endif
-    return (size_t)(ret_slot);
-}
-
-NOINLINE size_t my_fwrite(p_void ptr, size_t size, size_t count, FILE* stream)
-{
-#ifdef WIN32
-    DWORD ret_slot;
-
-    WriteFile((HANDLE)stream, ptr, size * count, &ret_slot, NULL);
-#else
-    size_t ret_slot;
-
-    ret_slot = fwrite(ptr, size, count, stream);
-#endif
-    return (size_t)(ret_slot);
-}

--- a/module.h
+++ b/module.h
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  Module Subsystem Interface to SP Interpreter Core                  *
 * Authors:  Iconoclast                                                         *
-* Release:  2016.11.05                                                         *
+* Release:  2018.03.17                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -26,7 +26,9 @@ typedef enum {
     M_NJPEGTASK = 4,
     M_NULTASK   = 5,
     M_HVQTASK   = 6,
-    M_HVQMTASK  = 7
+    M_HVQMTASK  = 7,
+
+    NUM_KNOWN_TASK_TYPES
 } OSTask_type;
 
 #define CFG_FILE    "rsp_conf.bin"
@@ -86,22 +88,5 @@ static FILE *output_log;
 extern void step_SP_commands(u32 inst);
 #endif
 extern void export_SP_memory(void);
-
-/*
- * low-level recreations of the C standard library functions for operating
- * systems that provide an inconvenient C run-time ecosystem, like Windows
- */
-NOINLINE extern p_void my_calloc(size_t count, size_t size);
-NOINLINE extern void my_free(p_void ptr);
-NOINLINE extern size_t my_strlen(const char* str);
-NOINLINE extern char* my_strcpy(char* destination, const char* source);
-NOINLINE extern char* my_strcat(char* destination, const char* source);
-NOINLINE extern int my_system(char* command);
-NOINLINE extern FILE* my_fopen(const char * filename, const char* mode);
-NOINLINE extern int my_fclose(FILE* stream);
-NOINLINE extern size_t my_fread(
-    p_void ptr, size_t size, size_t count, FILE* stream);
-NOINLINE extern size_t my_fwrite(
-    p_void ptr, size_t size, size_t count, FILE* stream);
 
 #endif

--- a/vu/add.c
+++ b/vu/add.c
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  MSP Simulation Layer for Vector Unit Computational Adds            *
 * Authors:  Iconoclast                                                         *
-* Release:  2016.03.23                                                         *
+* Release:  2018.03.18                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -72,7 +72,7 @@ static INLINE void SIGNED_CLAMP_ADD(pi16 VD, pi16 VS, pi16 VT)
 {
     i32 sum[N];
     i16 hi[N], lo[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         sum[i] = VS[i] + VT[i] + cf_co[i];
@@ -93,7 +93,7 @@ static INLINE void SIGNED_CLAMP_SUB(pi16 VD, pi16 VS, pi16 VT)
 {
     i32 dif[N];
     i16 hi[N], lo[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         dif[i] = VS[i] - VT[i] - cf_co[i];
@@ -114,7 +114,7 @@ static INLINE void SIGNED_CLAMP_SUB(pi16 VD, pi16 VS, pi16 VT)
 
 INLINE static void clr_ci(pi16 VD, pi16 VS, pi16 VT)
 { /* clear CARRY and carry in to accumulators */
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         VACC_L[i] = VS[i] + VT[i] + cf_co[i];
@@ -128,7 +128,7 @@ INLINE static void clr_ci(pi16 VD, pi16 VS, pi16 VT)
 
 INLINE static void clr_bi(pi16 VD, pi16 VS, pi16 VT)
 { /* clear CARRY and borrow in to accumulators */
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         VACC_L[i] = VS[i] - VT[i] - cf_co[i];
@@ -151,7 +151,7 @@ INLINE static void do_abs(pi16 VD, pi16 VS, pi16 VT)
     i16 neg[N], pos[N];
     i16 nez[N], cch[N]; /* corner case hack -- abs(-32768) == +32767 */
     ALIGNED i16 res[N];
-    register int i;
+    register unsigned int i;
 
     vector_copy(res, VT);
     for (i = 0; i < N; i++)
@@ -180,7 +180,7 @@ INLINE static void do_abs(pi16 VD, pi16 VS, pi16 VT)
 INLINE static void set_co(pi16 VD, pi16 VS, pi16 VT)
 { /* set CARRY and carry out from sum */
     i32 sum[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         sum[i] = (u16)(VS[i]) + (u16)(VT[i]);
@@ -197,7 +197,7 @@ INLINE static void set_co(pi16 VD, pi16 VS, pi16 VT)
 INLINE static void set_bo(pi16 VD, pi16 VS, pi16 VT)
 { /* set CARRY and borrow out from difference */
     i32 dif[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         dif[i] = (u16)(VS[i]) - (u16)(VT[i]);

--- a/vu/select.c
+++ b/vu/select.c
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  MSP Simulation Layer for Vector Unit Computational Test Selects    *
 * Authors:  Iconoclast                                                         *
-* Release:  2015.01.30                                                         *
+* Release:  2018.03.18                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -29,7 +29,7 @@
  */
 static void merge(pi16 VD, pi16 cmp, pi16 pass, pi16 fail)
 {
-    register int i;
+    register unsigned int i;
 #if (0 != 0)
 /* Do not use this version yet, as it still does not vectorize to SSE2. */
     for (i = 0; i < N; i++)
@@ -49,7 +49,7 @@ INLINE static void do_lt(pi16 VD, pi16 VS, pi16 VT)
 {
     i16 cn[N];
     i16 eq[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         eq[i] = (VS[i] == VT[i]);
@@ -75,7 +75,7 @@ INLINE static void do_lt(pi16 VD, pi16 VS, pi16 VT)
 
 INLINE static void do_eq(pi16 VD, pi16 VS, pi16 VT)
 {
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cf_comp[i] = (VS[i] == VT[i]);
@@ -98,7 +98,7 @@ INLINE static void do_eq(pi16 VD, pi16 VS, pi16 VT)
 
 INLINE static void do_ne(pi16 VD, pi16 VS, pi16 VT)
 {
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cf_comp[i] = (VS[i] != VT[i]);
@@ -123,7 +123,7 @@ INLINE static void do_ge(pi16 VD, pi16 VS, pi16 VT)
 {
     i16 ce[N];
     i16 eq[N];
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         eq[i] = (VS[i] == VT[i]);
@@ -154,7 +154,7 @@ INLINE static void do_cl(pi16 VD, pi16 VS, pi16 VT)
     ALIGNED i16 gen[N], len[N], lz[N], uz[N], sn[N];
     i16 diff[N];
     i16 cmp[N];
-    register int i;
+    register unsigned int i;
 
     vector_copy((pi16)VB, VS);
     vector_copy((pi16)VC, VT);
@@ -230,7 +230,7 @@ INLINE static void do_ch(pi16 VD, pi16 VS, pi16 VT)
     i16 diff[N];
 #endif
     i16 cch[N]; /* corner case hack:  -(-32768) with undefined sign */
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cch[i] = (VT[i] == -32768) ? ~0 : 0; /* -(-32768) might not be >= 0. */
@@ -297,7 +297,7 @@ INLINE static void do_cr(pi16 VD, pi16 VS, pi16 VT)
     ALIGNED i16 ge[N], le[N], sn[N];
     ALIGNED i16 VC[N];
     i16 cmp[N];
-    register int i;
+    register unsigned int i;
 
     vector_copy(VC, VT);
     for (i = 0; i < N; i++)

--- a/vu/vu.c
+++ b/vu/vu.c
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  MSP Emulation Layer for Vector Unit Computational Operations       *
 * Authors:  Iconoclast                                                         *
-* Release:  2016.03.23                                                         *
+* Release:  2018.03.18                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -133,19 +133,20 @@ u16 get_VCC(void)
 }
 u8 get_VCE(void)
 {
-    int result;
+    unsigned int result;
     register u8 vce;
 
     result = 0x00
-      | (cf_vce[07] << 0x7)
-      | (cf_vce[06] << 0x6)
-      | (cf_vce[05] << 0x5)
-      | (cf_vce[04] << 0x4)
-      | (cf_vce[03] << 0x3)
-      | (cf_vce[02] << 0x2)
-      | (cf_vce[01] << 0x1)
-      | (cf_vce[00] << 0x0);
-    vce = result & 0xFF;
+      | (cf_vce[0x7] << 0x7)
+      | (cf_vce[0x6] << 0x6)
+      | (cf_vce[0x5] << 0x5)
+      | (cf_vce[0x4] << 0x4)
+      | (cf_vce[0x3] << 0x3)
+      | (cf_vce[0x2] << 0x2)
+      | (cf_vce[0x1] << 0x1)
+      | (cf_vce[0x0] << 0x0)
+    ;
+    vce = (u8)(result & 0xFF);
     return (vce); /* Big endian becomes little. */
 }
 #else
@@ -207,7 +208,7 @@ u8 get_VCE(void)
  */
 void set_VCO(u16 vco)
 {
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cf_co[i] = (vco >> (i + 0x0)) & 1;
@@ -217,7 +218,7 @@ void set_VCO(u16 vco)
 }
 void set_VCC(u16 vcc)
 {
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cf_comp[i] = (vcc >> (i + 0x0)) & 1;
@@ -227,7 +228,7 @@ void set_VCC(u16 vcc)
 }
 void set_VCE(u8 vce)
 {
-    register int i;
+    register unsigned int i;
 
     for (i = 0; i < N; i++)
         cf_vce[i] = (vce >> i) & 1;


### PR DESCRIPTION
Even though most of the commits contained changes that didn't really affect this fork there were still a few that did, so I figured it'd be worth a merge.

To be safe I went through the commits one by one to check for any issues after the merge and as far as I can tell everything should be fine (though I was only able to test a MinGW build, would be nice if someone could build with MSVC and test that one).

The only things that might be worth mentioning are:
- I don't think `make.sh` can be used anymore for upstream MinGW builds (due to an added linkage with libc), just use the `make_w32/64.cmd` scripts instead (mupen64's Makefile still works fine though)

- I removed the `COMPILER_FENCE()` statements in `vu/multiply.c` due to commits https://github.com/cxd4/rsp/commit/b9e6b43ce59136ecc1cdd3a7cf63890cd0df8dff and https://github.com/cxd4/rsp/commit/b9e6b43ce59136ecc1cdd3a7cf63890cd0df8dff . I'm not really sure if they can be safely removed or are still needed somewhere else now, maybe @fzurita can clarify?
