### PR TITLE
build: Allow out of tree builds.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -118,7 +118,7 @@ endif
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I../../
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I$(SRCDIR)
 CPPFLAGS += -DM64P_PLUGIN_API
 LDFLAGS += $(SHARED)
 


### PR DESCRIPTION
This allows building the project out of tree.

Example:
```
mkdir /tmp/build
cd /tmp/build
make install -f /path/to/mupen64plus-rsp-cxd4/projects/unix/Makefile \
  SRCDIR=/path/to/mupen64plus-rsp-cxd4
```
Also see PR https://github.com/mupen64plus/mupen64plus-core/pull/811 for reference.