### PR TITLE
Add Aarch64

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -111,6 +111,12 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     $(warning Architecture "$(HOST_CPU)" not officially supported.')
   endif
 endif
+ifneq ("$(filter arm64 aarch64,$(HOST_CPU))","")
+  CPU := AARCH64
+  ARCH_DETECTED := 64BITS
+  PIC ?= 1
+  $(warning Architecture "$(HOST_CPU)" not officially supported.')
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif


### PR DESCRIPTION
This allows rsp-cxd to be built on aarch64 platforms.