### PR TITLE
CI/CD: Integrate scheduled builds and other...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
       - '**/*.md'
       - '.{gitattributes,gitignore,travis.yml}'
       - 'appveyor.yml,README'
+  schedule:
+    - cron: '35 14 21 * *'
   workflow_dispatch:
+
 jobs:
 
   Linux:
@@ -33,33 +36,31 @@ jobs:
             bits: 32
     name: Linux / ${{ matrix.cc }} / ${{ matrix.platform }}
     runs-on: ubuntu-22.04
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-rsp-cxd4') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v3
       - name: Get build dependencies and arrange the environment
         run: |
+          echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
           sudo apt-get update
           sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386
           sudo ldconfig
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
-          G_REV=$(git rev-parse --short HEAD)
-          echo "G_REV=${G_REV}" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1" CPU_TUNE="-mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
-          if [[ "${{ matrix.cc }}" == "GCC" ]]; then
-            CC="gcc"
-            CXX="g++"
-          else
+          CC="gcc"
+          CXX="g++"
+          if [[ "${{ matrix.cc }}" != "GCC" ]]; then
             CC="clang"
             CXX="clang++"
           fi
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1"; fi
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
-          mkdir tmp
-          for SSE in none SSE2
-          do
+          mkdir pkg
+          for SSE in none SSE2; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }}${MSG} ::"
             echo ""
@@ -67,23 +68,21 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SSE="${SSE}" -C projects/unix all -j4
             echo ""
-            make SSE="${SSE}" -C projects/unix install DESTDIR="${ORIG}/tmp"
+            make SSE="${SSE}" -C projects/unix install DESTDIR="${ORIG}/pkg/"
             echo ""
-            cd tmp/usr/local/lib/mupen64plus
-            ls -gG mupen64plus-rsp-cxd4${LIB}.so
-            ldd mupen64plus-rsp-cxd4${LIB}.so
+            ls -gG pkg/usr/local/lib/mupen64plus/mupen64plus-rsp-cxd4${LIB}.so
+            echo ""
+            ldd pkg/usr/local/lib/mupen64plus/mupen64plus-rsp-cxd4${LIB}.so
             LIB="-sse2"
             MSG=" / SSE2"
-            cd "${ORIG}"
           done
-          mkdir pkg
-          if [[ "${CC}" == "gcc" ]]; then tar cvzf pkg/mupen64plus-rsp-cxd4-${{ matrix.platform }}-g${G_REV}.tar.gz -C tmp/ "usr"; fi
+          tar cvzf pkg/mupen64plus-rsp-cxd4-linux-${{ matrix.platform }}-g${{ env.G_REV }}.tar.gz -C pkg/ "usr"
       - name: Upload artifact
+        if: matrix.cc == 'GCC'
         uses: actions/upload-artifact@v3
         with:
-          name: mupen64plus-rsp-cxd4-${{ matrix.platform }}-g${{ env.G_REV }}
-          path: pkg/*
-          if-no-files-found: ignore
+          name: mupen64plus-rsp-cxd4-linux-${{ matrix.platform }}-g${{ env.G_REV }}
+          path: pkg/*.tar.gz
 
   MSYS2:
     strategy:
@@ -99,7 +98,8 @@ jobs:
             cross: i686
             bits: 32
     name: Windows / MSYS2 ${{ matrix.cc }} / ${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-rsp-cxd4') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: msys2 {0}
@@ -115,19 +115,19 @@ jobs:
             make
             mingw-w64-${{ matrix.cross }}-gcc
             mingw-w64-${{ matrix.cross }}-toolchain
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
           echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then CPU_TUNE="-mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
           CC="gcc"
           CXX="g++"
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
-          mkdir tmp
-          for SSE in none SSE2
-          do
+          mkdir pkg
+          for SSE in none SSE2; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }}${MSG} ::"
             echo ""
@@ -135,21 +135,13 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SSE="${SSE}" -C projects/unix all -j4
             echo ""
-            make SSE="${SSE}" -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/tmp"
+            make SSE="${SSE}" -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/pkg/"
             echo ""
-            ls -gG tmp/mupen64plus-rsp-cxd4${LIB}.dll
-            ldd tmp/mupen64plus-rsp-cxd4${LIB}.dll
+            ls -gG pkg/mupen64plus-rsp-cxd4${LIB}.dll
+            echo ""
+            ldd pkg/mupen64plus-rsp-cxd4${LIB}.dll
             LIB="-sse2"
             MSG=" / SSE2"
-          done
-      - name: Copy binaries, dependencies, etc...
-        run: |
-          mkdir pkg
-          cd tmp
-          for BIN in *.dll
-          do
-            echo ":: Copying ${BIN}"
-            cp "${BIN}" ../pkg/
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -168,37 +160,30 @@ jobs:
           - toolset: v141_xp
             platform: x86
             vs: 2019
-    name: Windows / MSVC ${{ matrix.toolset }} / ${{ matrix.platform }}
+    name: Windows / MSVC with ${{ matrix.toolset }} / ${{ matrix.platform }}
     runs-on: windows-${{ matrix.vs }}
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-rsp-cxd4') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: cmd
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1
-    #  with:
-    #    vs-version: 16.11
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do set "G_REV=%%R"
-          echo G_REV=%G_REV%>> "%GITHUB_ENV%"
+          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do echo G_REV=%%R>> "%GITHUB_ENV%"
           set "ARCH=${{ matrix.platform }}"
           if [%ARCH%] == [x86] set "ARCH=Win32"
           echo.
           msbuild --version
           echo.
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ..\mupen64plus-core
+          md pkg
           echo.
           msbuild projects\msvc\mupen64plus-rsp-cxd4.vcxproj /p:Configuration=Release;Platform=%ARCH%;PlatformToolset=${{ matrix.toolset }}
           echo.
-          md backup
-          copy projects\msvc\%ARCH%\Release\mupen64plus-rsp-cxd4.dll backup\
-          dir backup\*.dll
-      - name: Copy binaries, dependencies, etc...
-        run: |
-          md pkg
-          cd pkg
-          xcopy "..\backup" .
+          copy "projects\msvc\%ARCH%\Release\mupen64plus-rsp-cxd4.dll" pkg\
+          dir pkg\*.dll
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -207,8 +192,8 @@ jobs:
 
   Nightly-build:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master'
     needs: [Linux, MSYS2, MSVC]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
@@ -223,8 +208,7 @@ jobs:
         run: |
           mkdir pkg
           cd binaries
-          for BIN in *
-          do
+          for BIN in *; do
             cd "${BIN}"
             if [[ "${BIN:21:4}" == "msys" ]]; then
               echo ":: Creating ${BIN}.zip"
@@ -240,10 +224,9 @@ jobs:
           done
           cd ../pkg
           echo ""
-          for BIN in *
-          do
+          for BIN in *; do
             ls -gG ${BIN}
-            tigerdeep -l ${BIN} >> ../${BIN:0:20}.tiger.txt
+            tigerdeep -lz ${BIN} >> ../${BIN:0:20}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:20}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:20}.sha512.txt
           done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 
 image: Visual Studio 2022
 
+skip_tags: true
+
 skip_commits:
   files:
     - '**/*.md'
@@ -11,10 +13,6 @@ skip_commits:
     - .gitignore
     - .travis.yml
     - README
-
-branches:
-  except:
-    - nightly-build
 
 configuration:
   - Release


### PR DESCRIPTION
Relevant changes:

- Schedule builds at least once a month (upstream only)
- Update some GitHub Actions values
- Bash code simplification and corrections
- Tag to Linux binaries
- Add file size to tiger hashfile
- AppVeyor: Avoid duplicated jobs as a result of the `nightly-build` tag update