### PR TITLE
CI/CD: Add BLAKE2 hashfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,9 +229,11 @@ jobs:
             tigerdeep -lz ${BIN} >> ../${BIN:0:20}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:20}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:20}.sha512.txt
+            b2sum ${BIN} >> ../${BIN:0:20}.blake2.txt
           done
           mv ../*.tiger.txt .
           mv ../*.sha*.txt .
+          mv ../*.blake2.txt .
           echo ""
           echo "TIGER:"
           cat *.tiger.txt
@@ -241,6 +243,9 @@ jobs:
           echo ""
           echo "SHA512:"
           cat *.sha512.txt
+          echo ""
+          echo "BLAKE2:"
+          cat *.blake2.txt
           echo ""
           git tag -f nightly-build
           git push -f origin nightly-build


### PR DESCRIPTION
> This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days. Enable this workflow to resume scheduled runs.

This is disabling all GitHub Actions, not just scheduled workflows... to re-enable: Actions > CXD4 RSP