### PR TITLE
Renormalize osal_dynamiclib_win32.c and more...

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@ RELEASE text
 *.ver text
 
 # windows specific text files
+*.cmd text eol=crlf
 *.sln text eol=crlf
 *.vcproj text eol=crlf
 *.vcxproj text eol=crlf

--- a/osal_dynamiclib_win32.c
+++ b/osal_dynamiclib_win32.c
@@ -36,7 +36,7 @@ m64p_error osal_dynlib_open(m64p_dynlib_handle *pLibHandle, const char *pccLibra
     if (*pLibHandle == NULL)
     {
         char *pchErrMsg;
-        DWORD dwErr = GetLastError(); 
+        DWORD dwErr = GetLastError();
         FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwErr,
                       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &pchErrMsg, 0, NULL);
         fprintf(stderr, "LoadLibrary('%s') error: %s\n", pccLibraryPath, pchErrMsg);
@@ -62,7 +62,7 @@ m64p_error osal_dynlib_close(m64p_dynlib_handle LibHandle)
     if (rval == 0)
     {
         char *pchErrMsg;
-        DWORD dwErr = GetLastError(); 
+        DWORD dwErr = GetLastError();
         FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwErr,
                       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &pchErrMsg, 0, NULL);
         fprintf(stderr, "FreeLibrary() error: %s\n", pchErrMsg);


### PR DESCRIPTION
Consider this a direct continuation of https://github.com/mupen64plus/mupen64plus-rsp-cxd4/pull/48#issuecomment-591544822

To truly understand what this corrects, do this experiment and compare the results:

```
git clone --depth 1 -b master --single-branch https://github.com/mupen64plus/mupen64plus-rsp-cxd4.git mupen64plus-rsp-cxd4_master
cd mupen64plus-rsp-cxd4_master
git status
git ls-files --eol

```

```
git clone --depth 1 -b renor --single-branch https://github.com/Jj0YzL5nvJ/mupen64plus-rsp-cxd4.git mupen64plus-rsp-cxd4_renor
cd mupen64plus-rsp-cxd4_renor
git status
git ls-files --eol

```