### PR TITLE
gitattributes: Remove forced-eol output filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,11 +26,11 @@ RELEASE text
 *.ver text
 
 # windows specific text files
-*.cmd text eol=crlf
-*.sln text eol=crlf
-*.vcproj text eol=crlf
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
+*.cmd text
+*.sln text
+*.vcproj text
+*.vcxproj text
+*.vcxproj.filters text
 
 # binary files
 *.gz binary


### PR DESCRIPTION
After the xz backdoor incident [1] in 2024, distributions began investing in countermeasures against the attack vectors that were used. Among other efforts, they started comparing published git sources against release tarballs - and some switched to using git directly as the primary source for their builds.

Distributions that perform these integrity checks typically clone repositories with output filters disabled. This prevents on-checkout file modifications, which could either serve as an attack vector or break reproducibility. Since .gitattributes offers no fine-grained  control over this, many tools disable it entirely during checkout.

This is why mupen64plus triggers errors like:

    changes detected, the modified files are:
     source_dir/projects/msvc/mupen64plus-*.vcxproj
 
The root cause is the eol output filter. To understand why:

* The text attribute acts as both an input and output filter. The input side normalizes line endings to LF before committing; the output side converts them back to either the configured or platform-native ending on checkout.

* The eol attribute overrides this, forcing a specific line ending regardless of platform convention on checkout.

In practice, this is unnecessary:

* On Linux, files are already stored with LF in git's object store - no output conversion needed.

* On Windows, a standard git clone already produces CRLF correctly.

* For cross-compiling Windows binaries on Linux, msbuild parses parses both line endings as needed.

Removing the forced eol output filter simplifies the checkout behavior, eliminates unnecessary file modifications, and avoids false positives in source integrity checks that compare tarballs against git checkout (variants).
 
[1] https://en.wikipedia.org/wiki/XZ_Utils_backdoor