### PR TITLE
Fix SP DMA crossing the DMEM/IMEM bank boundary instead of wrapping within the 4KB bank

### DIFF
--- a/su.c
+++ b/su.c
@@ -234,7 +234,8 @@ void SP_DMA_READ(void)
         i = 0;
         --count;
         do {
-            offC = (count*length + *CR[0x0] + i) & 0x00001FF8ul;
+            offC = ((count*length + *CR[0x0] + i) & 0x00000FF8ul)
+                 | (*CR[0x0] & 0x00001000ul);
             offD = (count*skip + *CR[0x1] + i) & 0x00FFFFF8ul;
             i += 0x008;
             if (offD > su_max_address) {
@@ -245,8 +246,6 @@ void SP_DMA_READ(void)
         } while (i < length);
     } while (count);
 
-    if ((*CR[0x0] ^ offC) & 0x1000)
-        message("DMA over the DMEM-to-IMEM gap.");
     GET_RCP_REG(SP_DMA_BUSY_REG)  =  0x00000000;
     GET_RCP_REG(SP_STATUS_REG)   &= ~SP_STATUS_DMA_BUSY;
     return;
@@ -274,7 +273,8 @@ void SP_DMA_WRITE(void)
         i = 0;
         --count;
         do {
-            offC = (count*length + *CR[0x0] + i) & 0x00001FF8ul;
+            offC = ((count*length + *CR[0x0] + i) & 0x00000FF8ul)
+                 | (*CR[0x0] & 0x00001000ul);
             offD = (count*skip + *CR[0x1] + i) & 0x00FFFFF8ul;
             i += 0x000008;
             if (offD > su_max_address)
@@ -283,8 +283,6 @@ void SP_DMA_WRITE(void)
         } while (i < length);
     } while (count);
 
-    if ((*CR[0x0] ^ offC) & 0x1000)
-        message("DMA over the DMEM-to-IMEM gap.");
     GET_RCP_REG(SP_DMA_BUSY_REG)  =  0x00000000;
     GET_RCP_REG(SP_STATUS_REG)   &= ~SP_STATUS_DMA_BUSY;
     return;


### PR DESCRIPTION
## Summary

`SP_DMA_READ` and `SP_DMA_WRITE` compute the RSP-side DMA offset as:

```c
offC = (count*length + *CR[0x0] + i) & 0x00001FF8ul;
```

This treats DMEM+IMEM as one contiguous 8KB space, so a transfer that starts near the end of DMEM continues into IMEM (and vice versa). Real hardware instead wraps the address within the selected 4KB bank: bit 12 of `SP_MEM_ADDR` is the bank-select bit (`MEM_BANK`) and is not part of the incrementing counter. Per the [n64brew RSP Interface documentation](https://n64brew.dev/wiki/Reality_Signal_Processor/Interface): "A single DMA transfer can only transfer to/from one of DMEM or IMEM... If the transfer hits the end of either memory area, it wraps around to the beginning of it."

The code even anticipates the case, but only warns:

```c
if ((*CR[0x0] ^ offC) & 0x1000)
    message("DMA over the DMEM-to-IMEM gap.");
```

## Fix

In both functions, wrap within the 4KB bank and preserve the bank bit:

```c
offC = ((count*length + *CR[0x0] + i) & 0x00000FF8ul)
     | (*CR[0x0] & 0x00001000ul);
```

This makes the gap warning unreachable, so this PR removes both occurrences; happy to keep/repurpose it as a wrap notice instead if preferred.

## Trigger condition and impact

The bug triggers whenever `(SP_MEM_ADDR & 0xFFF) + length > 0x1000`. Retail games never issue bank-straddling DMAs, which is presumably why this has gone unnoticed, but modern homebrew does: under libdragon's rspq microcode, `SP_DMA_WRITE` exported RSP microcode/state from the wrong bank into RDRAM every frame (observed landing mid-Z-buffer at `0x7ca800`), producing depth-rejection artifacts on all geometry.

## Testing

- With this change, a libdragon test ROM (Pyrite64 `test.z64`) that previously showed persistent RDRAM corruption rendered correctly with no artifacts over a 90-second run (cxd4 + angrylion).
- Builds cleanly with `make` (projects/unix).
- No regression testing was done against retail ROMs; retail microcodes never trigger the changed path's wrap behavior, but stating this honestly rather than claiming it was tested.

If there is any doubt about the hardware behavior, a trivial hardware test settles it: DMA with `MEM_ADDR = 0xFF8`, `length = 0x10`, then read back DMEM `0x000` — the tail of the transfer lands at the start of DMEM, not in IMEM.
